### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/app/bbgt/[slug]/page.tsx
+++ b/src/app/bbgt/[slug]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   const slug = params.slug
-  const decodedSlug = slug.replace('%2C', ',')
+  const decodedSlug = slug.replace(/%2C/g, ',')
   const sign = await getRoadSignById(decodedSlug)
   if (!sign) {
     return { title: 'Not Found' }
@@ -49,7 +49,7 @@ export async function generateMetadata(
 
 export default async function RoadSignPage({ params }: Props) {
   const slug = params.slug
-  const decodedSlug = slug.replace('%2C', ',')
+  const decodedSlug = slug.replace(/%2C/g, ',')
   const signWithAround = await getRoadSignsWithAroundById(decodedSlug)
   if (!signWithAround) {
     return <>Not Found</>


### PR DESCRIPTION
Potential fix for [https://github.com/lethang7794/gtdb/security/code-scanning/2](https://github.com/lethang7794/gtdb/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of `%2C` in the `slug` are replaced with a comma. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that all instances of `%2C` are correctly decoded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
